### PR TITLE
mintty: prepare for v3.6.1

### DIFF
--- a/mintty/0001-add-msys2-launcher.patch
+++ b/mintty/0001-add-msys2-launcher.patch
@@ -46,7 +46,7 @@ index 63e6a69..0be9369 100644
 -#define APPDESC "Terminal"
 +#define APPDESC "MSYS2 terminal"
  #define AUTHOR  "Thomas Wolff / Andy Koppe"
- #define YEAR    "2022 / 2013"
+ #define YEAR    "2022"
  
 diff --git a/src/launcher.c b/src/launcher.c
 new file mode 100644


### PR DESCRIPTION
This should fix the MinTTY 3.6.1 [build failures](https://github.com/git-for-windows/git/issues/3820#issuecomment-1108788027).